### PR TITLE
Add package inclusion for Python files in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ version = "0.1.1"
 description = ""
 authors = ["Patrick Rachford <prachford@icloud.com>"]
 readme = "README.md"
+packages = [
+    { include = "*.py" }
+]
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION

I was getting this damn error:
```sh
$poetry install
Installing dependencies from lock file

Package operations: 13 installs, 0 updates, 0 removals

  - Installing markupsafe (2.1.5)
  - Installing asgiref (3.8.1)
  - Installing blinker (1.8.2)
  - Installing click (8.1.7)
  - Installing itsdangerous (2.2.0)
  - Installing jinja2 (3.1.4)
  - Installing protobuf (5.26.1)
  - Installing types-protobuf (5.26.0.20240422)
  - Installing typing-extensions (4.11.0)
  - Installing werkzeug (3.0.3)
  - Installing flask (3.0.3)
  - Installing temporalio (1.5.1)
  - Installing ruff (0.4.3)

Installing the current project: Saga (0.1.1)
Error: The current project could not be installed: No file/folder found for package saga
If you do not want to install the current project use --no-root.
If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
If you did intend to install the current project, you may need to set `packages` in your pyproject.toml file.

```

# Poetry Package Configuration Update

## Changes Made
- Updated `pyproject.toml` to include proper package configuration
- Added `packages` configuration to properly include Python files
- Fixed Poetry installation issues

## Technical Details
Modified the `pyproject.toml` configuration to include:
```toml
[tool.poetry]
packages = [
    { include = "*.py" }
]
```

## Testing Done
- Verified that `poetry install` completes successfully
- Checked that package dependencies are correctly resolved
- Ensured development environment setup works as expected

## Related Issues
Fixes #[issue_number] - Poetry installation fails due to missing package configuration

## Notes for Reviewers
Please verify that:
- The package installation works in your environment
- All dependencies are correctly resolved
- The project structure remains intact